### PR TITLE
Improve TypeScript syntax in functional component snippets

### DIFF
--- a/snippets/tsx.json
+++ b/snippets/tsx.json
@@ -2,13 +2,13 @@
   "Functional Component (const)": {
     "prefix": "rfc",
     "body": [
-      "${4:import type { FC \\} from 'react';}",
-      "${4:",
+      "import type { FC } from 'react';",
+      "",
       "interface ${1:ComponentName}Props {",
       "  ${2:propName}: ${3:type};",
-      "\\}",
       "}",
-      "const ${1:ComponentName}${4:: FC<${1:ComponentName}Props>} = (${4:{ ${2:propName} \\}}) => {",
+      "",
+      "const ${1:ComponentName}: FC<${1:ComponentName}Props> = ({ ${2:propName} }) => {",
       "  return (",
       "    <div>",
       "      $0",
@@ -23,12 +23,11 @@
   "Functional Component (function)": {
     "prefix": "rff",
     "body": [
-      "${4:",
       "interface ${1:ComponentName}Props {",
       "  ${2:propName}: ${3:type};",
-      "\\}",
       "}",
-      "export default function ${1:ComponentName}(${4:{ ${2:propName} \\}: ${1:ComponentName}Props}) {",
+      "",
+      "export default function ${1:ComponentName}({ ${2:propName} }: ${1:ComponentName}Props) {",
       "  return (",
       "    <div>",
       "      $0",


### PR DESCRIPTION
## Description

Improve TypeScript syntax in functional component snippets

## Type of Change

- [ ] New snippet(s)
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe)

## Snippets Added/Modified

- `"${4:import type { FC \\} from 'react';}",` - Escape character altered the snippet.
- Took off ${4: for simplicity in fix

## Testing

- [x] Tested in Zed IDE
- [x] All placeholders work correctly
- [x] Follows existing conventions

## Screenshots (if applicable)
Before
<img width="655" height="374" alt="Screenshot 2026-06-27 at 11 59 12 PM" src="https://github.com/user-attachments/assets/5d94da6f-fd24-43e3-8a14-ca83a6e55edb" />

After
<img width="632" height="374" alt="Screenshot 2026-06-27 at 11 53 42 PM" src="https://github.com/user-attachments/assets/e8a46bee-34ea-42b9-a291-9c2c0bb9ff92" />
